### PR TITLE
Earlier release in handleAPIResponse method

### DIFF
--- a/Dailymotion.m
+++ b/Dailymotion.m
@@ -425,7 +425,6 @@ NSString * const DailymotionApiErrorDomain = @"DailymotionApiErrorDomain";
             NSDictionary *call = [callQueue objectForKey:callId];
             id delegate = [call objectForKey:@"delegate"];
             NSDictionary *userInfo = [call valueForKey:@"userInfo"];
-            [callQueue removeObjectForKey:callId];
 
             if ([result objectForKey:@"error"])
             {
@@ -467,6 +466,7 @@ NSString * const DailymotionApiErrorDomain = @"DailymotionApiErrorDomain";
                     [delegate dailymotion:self didReturnResult:[result objectForKey:@"result"] userInfo:userInfo];
                 }
             }
+            [callQueue removeObjectForKey:callId];
         }
 
         [self resetAPIConnection];


### PR DESCRIPTION
When [callQueue removeObjectForKey:callId] is called, the userInfo dictionnary is released, so the userInfo object passed in delegate methods is zombie.
To fix this, the remove object is called when all delegate methods have been called. 
