### PR TITLE
Fix a conflict with UIAlertView categories.

### DIFF
--- a/Dailymotion SDK.xcodeproj/project.pbxproj
+++ b/Dailymotion SDK.xcodeproj/project.pbxproj
@@ -551,7 +551,7 @@
 			attributes = {
 				LastUpgradeCheck = 0430;
 			};
-			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "Dailymotion SDK iOS" */;
+			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "Dailymotion SDK" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
@@ -899,7 +899,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "Dailymotion SDK iOS" */ = {
+		1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "Dailymotion SDK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DEB922308733DC00010E9CD /* Debug */,

--- a/Dailymotion SDK/Player/DMPlayerViewController.m
+++ b/Dailymotion SDK/Player/DMPlayerViewController.m
@@ -233,10 +233,10 @@
     }
     else
     {
-        [UIAlertView showAlertViewWithTitle:[NSString stringWithFormat:NSLocalizedString(@"You are about to leave %@", nil),
-                                             [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleExecutable"]]
+        [DMAlertView showAlertViewWithTitle:[NSString stringWithFormat:NSLocalizedString(@"You are about to leave %@", nil),
+                                                                       [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleExecutable"]]
                                     message:[NSString stringWithFormat:NSLocalizedString(@"Do you want to open %@ in Safari?", nil),
-                                             request.URL.host]
+                                                                       request.URL.host]
                           cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
                           otherButtonTitles:@[NSLocalizedString(@"Open", nil)]
                                dismissBlock:^(NSInteger buttonIndex) {[[UIApplication sharedApplication] openURL:request.URL];}

--- a/Dailymotion SDK/UIKit/DMItemCollectionViewController.m
+++ b/Dailymotion SDK/UIKit/DMItemCollectionViewController.m
@@ -69,7 +69,7 @@
 
 - (void)itemCollectionViewDataSource:(DMItemCollectionViewController *)dataSource didFailWithError:(NSError *)error
 {
-    [UIAlertView showAlertViewWithTitle:@"Error"
+    [DMAlertView showAlertViewWithTitle:@"Error"
                                 message:error.localizedDescription
                       cancelButtonTitle:@"Dismiss"
                       otherButtonTitles:nil

--- a/Dailymotion SDK/UIKit/DMItemTableViewController.m
+++ b/Dailymotion SDK/UIKit/DMItemTableViewController.m
@@ -96,7 +96,7 @@
 
 - (void)itemTableViewDataSource:(DMItemTableViewController *)dataSource didFailWithError:(NSError *)error
 {
-    [UIAlertView showAlertViewWithTitle:@"Error"
+    [DMAlertView showAlertViewWithTitle:@"Error"
                                 message:error.localizedDescription
                       cancelButtonTitle:@"Dismiss"
                       otherButtonTitles:nil

--- a/Dailymotion SDK/Utils/DMAlert.h
+++ b/Dailymotion SDK/Utils/DMAlert.h
@@ -6,12 +6,12 @@
 //
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef void (^DMAlertDismissBlock)(NSInteger buttonIndex);
 typedef void (^DMAlertCancelBlock)();
 
-@interface UIAlertView (DMBlock)
+@interface DMAlertView : UIAlertView
 
 + (UIAlertView *)showAlertViewWithTitle:(NSString *)title message:(NSString *)message cancelButtonTitle:(NSString *)cancelButtonTitle otherButtonTitles:(NSArray *)otherButtonTitles dismissBlock:(DMAlertDismissBlock)dismissBlock cancelBlock:(DMAlertCancelBlock)cancelBlock;
 

--- a/Dailymotion SDK/Utils/DMAlert.m
+++ b/Dailymotion SDK/Utils/DMAlert.m
@@ -11,13 +11,13 @@
 static DMAlertDismissBlock _dismissBlock;
 static DMAlertCancelBlock _cancelBlock;
 
-@implementation UIAlertView (DMBlock)
+@implementation DMAlertView
 
 + (UIAlertView *)showAlertViewWithTitle:(NSString *)title message:(NSString *)message cancelButtonTitle:(NSString *)cancelButtonTitle otherButtonTitles:(NSArray *)otherButtonTitles dismissBlock:(DMAlertDismissBlock)dismissBlock cancelBlock:(DMAlertCancelBlock)cancelBlock
 {
     _cancelBlock = cancelBlock;
     _dismissBlock = dismissBlock;
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:[self self] cancelButtonTitle:cancelButtonTitle otherButtonTitles:nil];
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:nil];
     for (NSString *buttonTitle in otherButtonTitles)
     {
         [alertView addButtonWithTitle:buttonTitle];


### PR DESCRIPTION
Some external libraries use the same trick of DMAlert to provide blocks
instead of a delegate for UIAlertView completion.
When 2 libraries (for instance, UIKitCategoryAdditions and DMAlert)
using this same trick are used in the same project, one of the category
will not work anymore.

This patch fixes the issue by creating a sub-class of UIAlertView
instead of creating a category.
