### PR TITLE
Fix crash iOS 5

### DIFF
--- a/Dailymotion SDK/Networking/DMNetworking.m
+++ b/Dailymotion SDK/Networking/DMNetworking.m
@@ -178,15 +178,13 @@ NSUInteger totalRequestCount;
 
     if (!deviceIdentifierInited)
     {
-        if (![UIDevice.currentDevice respondsToSelector:@selector(identifierForVendor)])
-        {
-            deviceIdentifierInited = YES;
-        }
-        if (UIDevice.currentDevice.identifierForVendor)
+	//iOS 6 and up
+        if ([UIDevice.currentDevice respondsToSelector:@selector(identifierForVendor)])
         {
             deviceIdentifier = UIDevice.currentDevice.identifierForVendor.UUIDString;
-            deviceIdentifierInited = YES;
         }
+
+	deviceIdentifierInited = YES;
     }
 
     return deviceIdentifier;


### PR DESCRIPTION
Fix crash when trying to access the identifierForVendor property while in iOS 5
